### PR TITLE
[Implementacao de rotina para expirar inscricoes]

### DIFF
--- a/event/apps.py
+++ b/event/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class EventConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'event'
+
+    def ready(self):
+        import event.signals

--- a/event/signals.py
+++ b/event/signals.py
@@ -1,0 +1,8 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from .models import Eventos, Inscricao
+
+@receiver(post_save, sender=Eventos)
+def expire_subscriptions_from_finished_events(send, instance, **kwargs):
+    if instance.status == 0:
+        Inscricao.objects.filter(id_evento=instance.id, status=0).update(status=2)


### PR DESCRIPTION
   - Implementado signal para verificar quando o evento e fechado e expirar as inscricoes não validadas.
   - Registrado signal a inicializacao do app de eventos.